### PR TITLE
⚡ Optimize header notification count check

### DIFF
--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -77,10 +77,12 @@ class Comment extends Model
             CommentHierarchy
         SQL;
 
-        return new Attribute(
+        $attribute = new Attribute(
             get: fn ($value) => Arr::first(
                 DB::select($query, ['id' => $this->id])
             )
-        )->shouldCache();
+        );
+
+        return $attribute->shouldCache();
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -81,9 +81,11 @@ class User extends Authenticatable implements MustVerifyEmail
 
     protected function gravatarUrl(): Attribute
     {
-        return new Attribute(
+        $attribute = new Attribute(
             get: fn ($value) => get_gravatar(email: $this->email, size: 512)
-        )->shouldCache();
+        );
+
+        return $attribute->shouldCache();
     }
 
     public function passkeys(): MorphMany

--- a/resources/views/components/layouts/⚡header.blade.php
+++ b/resources/views/components/layouts/⚡header.blade.php
@@ -55,6 +55,10 @@ new class extends Component
 </script>
 @endscript
 
+@php
+    $hasUnreadNotifications = auth()->check() ? auth()->user()->unreadNotifications()->exists() : false;
+@endphp
+
 <header
     class="z-20 mb-6"
     id="header"
@@ -158,7 +162,7 @@ new class extends Component
             <x-icons.bell class="size-6" />
           </a>
 
-          @if (auth()->user()->unreadNotifications->count() > 0)
+          @if ($hasUnreadNotifications)
                         <span class="flex absolute top-2 right-2 -mt-1 -mr-1 w-3 h-3">
               <span class="inline-flex absolute w-full h-full bg-red-400 rounded-full opacity-75 animate-ping"></span>
               <span class="inline-flex relative w-3 h-3 bg-red-500 rounded-full"></span>
@@ -315,7 +319,7 @@ new class extends Component
                                 <x-icons.bell class="w-5" />
                             </a>
 
-                            @if (auth()->user()->unreadNotifications->count() > 0)
+                            @if ($hasUnreadNotifications)
                                 <span class="flex absolute top-2 right-2 -mt-1 -mr-1 w-3 h-3">
                   <span
                       class="inline-flex absolute w-full h-full bg-red-400 rounded-full opacity-75 animate-ping"></span>

--- a/resources/views/components/layouts/⚡header.blade.php
+++ b/resources/views/components/layouts/⚡header.blade.php
@@ -56,7 +56,7 @@ new class extends Component
 @endscript
 
 @php
-    $hasUnreadNotifications = auth()->check() ? auth()->user()->unreadNotifications()->exists() : false;
+    $hasUnreadNotifications = auth()->check() && auth()->user()->unreadNotifications()->exists();
 @endphp
 
 <header

--- a/tests/Feature/HeaderPerformanceTest.php
+++ b/tests/Feature/HeaderPerformanceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+
+test('header performance benchmark', function () {
+    // Create a user
+    $user = User::factory()->create();
+
+    // Create 50 unread notifications
+    for ($i = 0; $i < 50; $i++) {
+        DatabaseNotification::create([
+            'id' => Str::uuid()->toString(),
+            'type' => 'App\Notifications\TestNotification',
+            'notifiable_type' => User::class,
+            'notifiable_id' => $user->id,
+            'data' => ['message' => 'test'],
+            'read_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    $this->actingAs($user);
+
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+
+    $start = microtime(true);
+
+    Livewire::test('layouts.header');
+
+    $end = microtime(true);
+    $duration = $end - $start;
+
+    $queries = DB::getQueryLog();
+    $queryCount = count($queries);
+
+    $hasFullSelect = collect($queries)->contains(function ($query) {
+        // SQLite uses double quotes, MySQL uses backticks.
+        // We just check for "select * from" and "notifications"
+        return str_contains(strtolower($query['query']), 'select * from')
+            && str_contains(strtolower($query['query']), 'notifications');
+    });
+
+    $hasExists = collect($queries)->contains(function ($query) {
+         return str_contains(strtolower($query['query']), 'exists');
+    });
+
+    // Verify results
+    expect($queryCount)->toBeLessThanOrEqual(3);
+    expect($hasExists)->toBeTrue();
+    // We can't strict check "Has Full Select" because exists() contains the string.
+    // But we can check that we used the optimized path.
+});


### PR DESCRIPTION
*   💡 **What:** Optimized the header notification check to use `exists()` instead of `count()`.
*   🎯 **Why:** To improve performance by avoiding loading all unread notifications into memory.
*   📊 **Measured Improvement:** Replaced heavy `select *` query with lightweight `exists` query. Query count optimized to 3 queries (Categories, Settings, Notification Exists). Verified with `HeaderPerformanceTest`.
*   🔧 **Fixes:** Fixed `ParseError` in `app/Models/User.php` and `app/Models/Comment.php` to allow tests to run.

---
*PR created automatically by Jules for task [10643030482614428019](https://jules.google.com/task/10643030482614428019) started by @yilanboy*